### PR TITLE
add pipefail to catch nordvpn errors, fix pass SERVER to nordvpn

### DIFF
--- a/scripts/nord_connect
+++ b/scripts/nord_connect
@@ -50,7 +50,8 @@ fi
 
 ## Make the connection
 current_sleep=1
-until nordvpn connect "${SERVER}" | grep -Ei -f /opt/reg-grep
+# Use pipefail to ensure we catch non zero exit codes
+until (set -o pipefail && nordvpn connect "${SERVER}" | grep -Ei -f /opt/reg-grep)
 do
   if [ ${current_sleep} -gt 32 ]
   then

--- a/scripts/nord_watch
+++ b/scripts/nord_watch
@@ -32,11 +32,16 @@ do
   ## Evaluate connection to internet
   if [[ ! $(curl -Is -m 5 -o /dev/null -w "%{http_code}" "${CHECK_CONNECTION_URL:-https://www.google.com}") =~ ^[23] ]]
   then
+    if [[ -n ${CONNECT} ]]
+      then
+        SERVER="${CONNECT}"
+    fi
+
     ## Show status and retry connection
     echo -e "$(date "+%F %T%z")\tWARNING\tUnstable connection detected"
     echo "########################"
     nordvpn status | grep -Eiv -f /opt/inv-grep
-    if ! nord_connect
+    if ! nord_connect "${SERVER}"
     then
       echo -e "$(date "+%F %T%z")\tCRITICAL\tUnable to connect; exiting"
       CODE=1


### PR DESCRIPTION
- Added in pipefail for the initial nordvpn connect sequence
- Made changes to pass CONNECT to nordvpn if present during an unstable reconnect.

The pipefail is required to catch edge cases where the initial connect fails with a non zero exit code.
For example, when connecting to nordvpn and the initial connection fails then nordvpn can sometimes respond with a non zero exit code. If this happens the grep doesn't run and as a result the until loop does not execute. This results in the container thinking nordvpn has connected successfully as all the exit logic is skipped. With pipefail the until loop is guaranteed to execute regardless of exit code.

Not sure if it was intentional to not pass CONNECT to nordvpn during reconnection, however without it nordvpn will obviously pick a random server. Providing CONNECT when present appears to be safe as CONNECT can be used with the nordvpn firewall. (eg "nordvpn connect NL")