### PR TITLE
Update connection command syntax in nord_connect script

### DIFF
--- a/scripts/nord_connect
+++ b/scripts/nord_connect
@@ -51,7 +51,7 @@ fi
 ## Make the connection
 current_sleep=1
 # Use pipefail to ensure we catch non zero exit codes
-until (set -o pipefail && nordvpn connect "${SERVER}" | grep -Ei -f /opt/reg-grep)
+until (set -o pipefail && nordvpn connect ${SERVER} | grep -Ei -f /opt/reg-grep)
 do
   if [ ${current_sleep} -gt 32 ]
   then


### PR DESCRIPTION
In lieu or creating a new env (e.g GROUP) and building logic around it, remove quotation to allow "-g|--group" passed via CONNECT env (e.g. -g p2p atlanta)